### PR TITLE
updated dependencies versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,9 +9,9 @@
         "email": "gabriele.brosulo@zirak.it"
     }],
     "require": {
-        "silverstripe/framework": "3.1.*",
-        "silverstripe/cms": "3.1.*",
-        "colymba/gridfield-bulk-editing-tools": "1.6.0",
+        "silverstripe/framework": "^3.1",
+        "silverstripe/cms": "^3.1",
+        "colymba/gridfield-bulk-editing-tools": "^2.1",
         "undefinedoffset/sortablegridfield" : "0.*"
     }
 }


### PR DESCRIPTION
This makes it possible to use simpleGallery with all 3.\* SilverStripe versions.

Before making a new release you should, however wait for the new GridFieldBulkEditingTools release that fixes a Bug on 3.2: https://github.com/colymba/GridFieldBulkEditingTools/issues/110
